### PR TITLE
Feature additional team members

### DIFF
--- a/wp-content/themes/engage/single.php
+++ b/wp-content/themes/engage/single.php
@@ -26,5 +26,7 @@ $context['primary'] = Timber::get_widgets('primary');
 if ( post_password_required( $post->ID ) ) {
 	Timber::render( 'single-password.twig', $context );
 } else {
+	# Set additional team members up, parse string into list of users
+	$post->additional_team_members = explode(', ', $post->additional_team_members);
 	Timber::render( array( 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ), $context, ENGAGE_PAGE_CACHE_TIME );
 }

--- a/wp-content/themes/engage/single.php
+++ b/wp-content/themes/engage/single.php
@@ -27,6 +27,6 @@ if ( post_password_required( $post->ID ) ) {
 	Timber::render( 'single-password.twig', $context );
 } else {
 	# Set additional team members up, parse string into list of users
-	$post->additional_team_members = explode(', ', $post->additional_team_members);
+	$context['post']->additional_team_members_list = explode(', ', $post->additional_team_members);
 	Timber::render( array( 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ), $context, ENGAGE_PAGE_CACHE_TIME );
 }

--- a/wp-content/themes/engage/templates/partial/article-footer.twig
+++ b/wp-content/themes/engage/templates/partial/article-footer.twig
@@ -1,3 +1,3 @@
 {% if post.post_type == 'research' and post.getResearchers %}
-{% include 'partial/researchers.twig' with { researchers: post.researchers } %}
+  {% include 'partial/researchers.twig' with { researchers: post.researchers, additionalTeamMembers: post.additional_team_members_list } %}
 {% endif %}

--- a/wp-content/themes/engage/templates/partial/article-meta.twig
+++ b/wp-content/themes/engage/templates/partial/article-meta.twig
@@ -50,6 +50,9 @@
             {% for researcher in post.getResearchers %}
                 {% include 'partial/teammate-tease.twig' with { mate: researcher } %}
             {% endfor %}
+            {% for researcher in post.additional_team_members_list %}
+                {% include 'partial/teammate-tease.twig' with { mate: researcher } %}
+            {% endfor %}
         </section>
     {% endif %}
 </div>

--- a/wp-content/themes/engage/templates/partial/researchers.twig
+++ b/wp-content/themes/engage/templates/partial/researchers.twig
@@ -1,6 +1,15 @@
 <section class="researchers">
 	<h3 class="researchers__title">Researchers</h3>
 	{% for researcher in researchers %}
-	{% include 'partial/teammate.twig' with { mate: researcher } %}
+		{% include 'partial/teammate.twig' with { mate: researcher } %}
+	{% endfor %}
+	{% for member in additionalTeamMembers %}
+		<div style="margin: 10px 0;" class="mate grid grid--col-12 grid--gap-20">
+				<div class="mate__content">
+					<h3 class="mate__name">
+							{{ member }}
+					</h3>
+				</div>
+		</div>
 	{% endfor %}
 </section>

--- a/wp-content/themes/engage/templates/partial/teammate-tease.twig
+++ b/wp-content/themes/engage/templates/partial/teammate-tease.twig
@@ -8,7 +8,7 @@
 	</div>
 	{% endif %}
 	<div class="mate__content">
-		<p class="mate__name">{{ mate.name ? mate.name : mate}}</p>
-		<p class="mate__labels">{{ mate.designation ? mate.designation : "Researcher" }}</p>
+		<p class="mate__name">{{ mate.name|default(mate) }}</p>
+		<p class="mate__labels">{{ mate.designation|default("Researcher") }}</p>
 	</div>
 </div>

--- a/wp-content/themes/engage/templates/partial/teammate-tease.twig
+++ b/wp-content/themes/engage/templates/partial/teammate-tease.twig
@@ -8,9 +8,7 @@
 	</div>
 	{% endif %}
 	<div class="mate__content">
-		<p class="mate__name">{{ mate.name }}</p>
-		 {% if mate.getDesignation %}
-		 <p class="mate__labels">{{ mate.designation }}</p>
-		 {% endif %}
+		<p class="mate__name">{{ mate.name ? mate.name : mate}}</p>
+		<p class="mate__labels">{{ mate.designation ? mate.designation : "Researcher" }}</p>
 	</div>
 </div>


### PR DESCRIPTION
Can now add additional team members to a research article by adding them to post as comma+space separated values, like "Team member 1, Team member 2"