### PR TITLE
Added option to hide feature image on posts

### DIFF
--- a/wp-content/themes/engage/templates/single.twig
+++ b/wp-content/themes/engage/templates/single.twig
@@ -5,6 +5,7 @@
         <div class="article__wrapper container container--lg">
             {% set hasVideo = post.getVideoEmbedLink and post.post_type != 'team' and post.post_type != 'board' %}
             {% set hasFeaturedImage = post.thumbnail.src and post.post_type != 'team' and post.post_type != 'board' %}
+            {% set displayFeaturedImage = post.feature_image_toggle %}
             <article class="article post-type-{{ post.post_type }} {{ hasFeaturedImage ? 'article--has-featured-img' }} {{ hasVideo ? 'article--has-video'}}" id="post-{{ post.ID }}">
                 <p class="article__post-type article__post-type--{{ post.post_type }}">{{ post.type.labels.singular_name }}</p>
                 <h1 class="article__title article__title--{{ post.post_type }}">{{ post.title }}</h1>
@@ -26,7 +27,7 @@
                         </iframe>
                       </div>
                     </div>
-                  {% elseif hasFeaturedImage %}
+                  {% elseif hasFeaturedImage and displayFeaturedImage == 'display' %}
                     <figure class="article__featured-img article__featured-img--{{ post.post_type }}">
                         <img class="featured-img__img" src="{{ post.thumbnail.src('featured-image') }}" {{ post.thumbnail.alt ? "alt='#{ post.thumbnail.alt}'" }} />
                         {% if post.thumbnail.caption %}

--- a/wp-content/themes/engage/templates/single.twig
+++ b/wp-content/themes/engage/templates/single.twig
@@ -5,7 +5,7 @@
         <div class="article__wrapper container container--lg">
             {% set hasVideo = post.getVideoEmbedLink and post.post_type != 'team' and post.post_type != 'board' %}
             {% set hasFeaturedImage = post.thumbnail.src and post.post_type != 'team' and post.post_type != 'board' %}
-            {% set displayFeaturedImage = post.feature_image_toggle %}
+            {% set hideFeaturedImage = post.hide_feature_image %}
             <article class="article post-type-{{ post.post_type }} {{ hasFeaturedImage ? 'article--has-featured-img' }} {{ hasVideo ? 'article--has-video'}}" id="post-{{ post.ID }}">
                 <p class="article__post-type article__post-type--{{ post.post_type }}">{{ post.type.labels.singular_name }}</p>
                 <h1 class="article__title article__title--{{ post.post_type }}">{{ post.title }}</h1>
@@ -27,7 +27,7 @@
                         </iframe>
                       </div>
                     </div>
-                  {% elseif hasFeaturedImage and displayFeaturedImage == 'display' %}
+                  {% elseif hasFeaturedImage and not hideFeaturedImage %}
                     <figure class="article__featured-img article__featured-img--{{ post.post_type }}">
                         <img class="featured-img__img" src="{{ post.thumbnail.src('featured-image') }}" {{ post.thumbnail.alt ? "alt='#{ post.thumbnail.alt}'" }} />
                         {% if post.thumbnail.caption %}


### PR DESCRIPTION
Added a way to toggle the display of the featured image at the top of a post for when the same picture is embedded on post for better style. By default the feature image is displayed at the top.

Need to add a new custom field when this gets pushed to the main site.