### PR TITLE
Reverted general page template to previous version without newsletter sidebar

### DIFF
--- a/wp-content/themes/engage/templates/page.twig
+++ b/wp-content/themes/engage/templates/page.twig
@@ -1,23 +1,17 @@
 {% extends "base.twig" %}
 
 {% block content %}
-<div class="post__wrapper wrapper--pad">
-    <div class="article__wrapper container container--lg">
-		
-	<article class="article container container--lg post-type--{{post.post_type}}" id="post--{{post.ID}}">
+	<article class="container container--md post-type--{{post.post_type}}" id="post--{{post.ID}}">
 		<header class="article__header">
 			<h1 class="article__title">{{post.title}}</h1>
 		</header>
-            
-        <aside class="newsletter-about widget">
-			{{ newsletter }}
-		</aside>
-
 		<div class="article__content">
 			{{post.content}}
 		</div>
-		
+		<div class="newsletter__wrapper">
+		  <div class="newsletter-page widget">
+		      {{ newsletter }}
+		  </div>
+		</div>
 	</article>
-	</div>
-</div>
 {% endblock %}


### PR DESCRIPTION
The general page template has been reverted to the older version without the newsletter sidebar. The coronavirus network coverage page now appears as follows.
![Screen Shot 2021-02-26 at 2 09 33 PM](https://user-images.githubusercontent.com/31896484/109349920-48d19e00-783c-11eb-91b0-41b5032f52d6.png)
