### PR TITLE
Feature staff page overhaul

### DIFF
--- a/wp-content/themes/engage/assets/scss/base/_variables.scss
+++ b/wp-content/themes/engage/assets/scss/base/_variables.scss
@@ -52,13 +52,13 @@ $verticals: (
   science-communication: "science-communication",
   media-ethics: "media-ethics",
   social-platforms: "social-platforms",
-  propaganda: "propaganda"
+  propaganda: "propaganda",
+  center-leadership: "center-leadership"
 );
 
 $teamCategories: (
-  visiting-scholar: "visiting-scholar",
-  administrative-and-technology: "administrative-and-technology",
-  center-leadership: "center-leadership"
+  collaborators: "collaborators",
+  administrative-and-technology: "administrative-and-technology"
 );
 
 $journalism-color: $teal;
@@ -80,23 +80,23 @@ $verticalColors: (
   journalism: $teal,
   journalism-faded: $journalism-color-faded,
   journalism-light: $teal-faded,
-  science-communication: $navy,
+  science-communication: $teal,
   science-communication-light: $blue-light,
   science-communication-faded: $science-communication-color-faded,
-  media-ethics: $green,
+  media-ethics: $teal,
   media-ethics-light: $green-light,
   media-ethics-faded: $media-ethics-color-faded,
-  social-platforms: $orange,
+  social-platforms: $teal,
   social-platforms-light: $orange-light,
   social-platforms-faded: $social-platforms-color-faded,
-  propaganda: $green-light,
-  propaganda-faded: $green-light-faded
+  propaganda: $teal,
+  propaganda-faded: $green-light-faded,
+  center-leadership: $teal
 );
 
 $categoryColors: (
-  visiting-scholar: $yellow,
-  administrative-and-technology: $orange-light,
-  center-leadership: $blue-light
+  collaborators: $teal,
+  administrative-and-technology: $teal
 );
 
 //== Scaffolding

--- a/wp-content/themes/engage/assets/scss/base/_variables.scss
+++ b/wp-content/themes/engage/assets/scss/base/_variables.scss
@@ -57,8 +57,8 @@ $verticals: (
 
 $teamCategories: (
   visiting-scholar: "visiting-scholar",
-  staff: "staff",
-  technology: "technology"
+  administrative-and-technology: "administrative-and-technology",
+  center-leadership: "center-leadership"
 );
 
 $journalism-color: $teal;
@@ -95,8 +95,8 @@ $verticalColors: (
 
 $categoryColors: (
   visiting-scholar: $yellow,
-  staff: $orange-light,
-  technology: $blue-light
+  administrative-and-technology: $orange-light,
+  center-leadership: $blue-light
 );
 
 //== Scaffolding

--- a/wp-content/themes/engage/src/Models/TeamArchive.php
+++ b/wp-content/themes/engage/src/Models/TeamArchive.php
@@ -49,6 +49,10 @@ class TeamArchive extends TileArchive
     // Splits the queried posts by designation, using the slugs as keys
     foreach($this->posts as $post) {
       $design_slug = $post->getTermDesign()[0]->slug;
+      if (!in_array($design_slug, ['director', 'assistant-director'], true )) {
+        $design_slug = "other";
+      }
+
       if (!array_key_exists ($design_slug, $groups)) {
         $groups[$design_slug] = array($post);
       }

--- a/wp-content/themes/engage/src/Models/TeamArchive.php
+++ b/wp-content/themes/engage/src/Models/TeamArchive.php
@@ -11,7 +11,7 @@ class TeamArchive extends TileArchive
   {
 
       parent::__construct($options, $query, $class);
-      if(is_post_type_archive("team")) {
+      if(is_post_type_archive("team") && $this->vertical) {
         $this->regroupByDesignation();
       }
       else {

--- a/wp-content/themes/engage/src/Models/TeamArchive.php
+++ b/wp-content/themes/engage/src/Models/TeamArchive.php
@@ -12,7 +12,12 @@ class TeamArchive extends TileArchive
 
       parent::__construct($options, $query, $class);
       if(is_post_type_archive("team") && $this->vertical) {
-        $this->regroupByDesignation();
+        $vertical = get_query_var('verticals', false);
+        if ($vertical == "center-leadership") {
+          $this->regroupByLeadershipPosition();
+        } else {
+          $this->regroupByDesignation();
+        }
       }
       else {
         usort($this->posts, [$this,"lastNameCompare"]);
@@ -29,8 +34,8 @@ class TeamArchive extends TileArchive
 
   function desigOrderCompare($a, $b) {
     // Gets the order # of each posts designation
-    $desigA = get_field('order', $a->getTermDesign()[0]);
-    $desigB = get_field('order', $b->getTermDesign()[0]);
+    $desigA = get_field('order', $a->getTermDesign()[0]) ?? 100;
+    $desigB = get_field('order', $b->getTermDesign()[0]) ?? 100;
     if ($desigA < $desigB) {
       return -1;
     }
@@ -67,5 +72,14 @@ class TeamArchive extends TileArchive
       usort($group, array($this, "lastNameCompare"));
       $this->posts = array_merge($this->posts, $group);
     }
+  }
+
+  public function regroupByLeadershipPosition() {
+    $order = array("Natalie (Talia) Jomini Stroud", "Gina M. Masullo", "Melody Avant", "Anthony Dudo", "Scott R. Stroud", "Samuel C. Woolley", "Katalina Deaven");
+    usort($this->posts, function ($a, $b) use ($order) {
+      $pos_a = array_search($a->name, $order);
+      $pos_b = array_search($b->name, $order);
+      return $pos_a - $pos_b;
+    });
   }
 }

--- a/wp-content/themes/engage/src/Models/Teammate.php
+++ b/wp-content/themes/engage/src/Models/Teammate.php
@@ -6,15 +6,14 @@ class Teammate extends Article {
 	public $name,
            $designation = false,
            $email = false,
-		   $phone = false,
+	   $phone = false,
            $external_link = false,
-		   $vertical = false,
-		   $termCat = false,
+           $vertical = false,
+           $termCat = false,
            $termDesign = false,
            $termSemester = false;
 
-	public function __construct($postID = null)
-    {
+    public function __construct($postID = null) {
         parent::__construct($postID);
         $this->name = $this->title;
     }

--- a/wp-content/themes/engage/src/Models/Teammate.php
+++ b/wp-content/themes/engage/src/Models/Teammate.php
@@ -6,11 +6,12 @@ class Teammate extends Article {
 	public $name,
            $designation = false,
            $email = false,
-		   		 $phone = false,
-					 $vertical = false,
-					 $termCat = false,
-                     $termDesign = false,
-                     $termSemester = false;
+		   $phone = false,
+           $external_link = false,
+		   $vertical = false,
+		   $termCat = false,
+           $termDesign = false,
+           $termSemester = false;
 
 	public function __construct($postID = null)
     {
@@ -39,31 +40,38 @@ class Teammate extends Article {
         return $this->phone;
     }
 
-		public function getVertical() {
-            if($this->vertical === false) {
-                $this->vertical = get_the_terms($this->ID, 'vertical');
-            }
-            return $this->vertical;
-		}
-
-		public function getTermCat() {
-			if($this->termCat === false) {
-				$this->termCat = get_the_terms($this->ID, 'team_category');
-            }
-			return $this->termCat;
-		}
-
-		public function getTermDesign() {
-			if($this->termDesign === false) {
-				$this->termDesign = get_the_terms($this->ID, 'team_designation');
-            }
-			return $this->termDesign;
+    public function getExternalLink() {
+        if($this->external_link === false) {
+            $this->external_link = get_post_meta($this->ID, 'member_external_link', true);
         }
+        return $this->external_link;
+    }
 
-        public function getTermSemester() {
-            if($this->termSemester === false) {
-                $this->termSemester = get_the_terms($this->ID, 'team_semester');
-            }
-            return $this->termSemester;
+    public function getVertical() {
+        if($this->vertical === false) {
+            $this->vertical = get_the_terms($this->ID, 'vertical');
         }
+        return $this->vertical;
+    }
+
+    public function getTermCat() {
+        if($this->termCat === false) {
+            $this->termCat = get_the_terms($this->ID, 'team_category');
+        }
+        return $this->termCat;
+    }
+
+    public function getTermDesign() {
+        if($this->termDesign === false) {
+            $this->termDesign = get_the_terms($this->ID, 'team_designation');
+        }
+        return $this->termDesign;
+    }
+
+    public function getTermSemester() {
+        if($this->termSemester === false) {
+            $this->termSemester = get_the_terms($this->ID, 'team_semester');
+        }
+        return $this->termSemester;
+    }
 }

--- a/wp-content/themes/engage/templates/partial/teammate.twig
+++ b/wp-content/themes/engage/templates/partial/teammate.twig
@@ -7,7 +7,11 @@
     <div class="mate__content">
       <h3 class="mate__name mate__name--{{ format }}">
           {% if (format == "preview" or "full") %}
-            <a class="mate__name" href="{{ mate.link }}">{{ mate.name }}</a>
+            {% if 'Visiting Scholar' in mate.getDesignation %}
+                <a class="mate__name" href="{{ mate.getExternalLink }}">{{ mate.name }}</a>
+            {% else %}
+                <a class="mate__name" href="{{ mate.link }}">{{ mate.name }}</a>
+            {% endif %}
           {% else %}
             {{ mate.name }}
           {% endif %}

--- a/wp-content/themes/engage/templates/partial/teammate.twig
+++ b/wp-content/themes/engage/templates/partial/teammate.twig
@@ -8,6 +8,8 @@
       <h3 class="mate__name mate__name--{{ format }}">
           {% if (format == "preview" or "full") %}
             {% if 'Visiting Scholar' in mate.getDesignation %}
+                {# Clicking on a Visiting Scholar redirects to an external page instead of
+                an internal bio page #}
                 <a class="mate__name" href="{{ mate.getExternalLink }}">{{ mate.name }}</a>
             {% else %}
                 <a class="mate__name" href="{{ mate.link }}">{{ mate.name }}</a>

--- a/wp-content/themes/engage/templates/partial/teammates.twig
+++ b/wp-content/themes/engage/templates/partial/teammates.twig
@@ -4,7 +4,7 @@
         {# PIs have their first vertical value as 'Center Leadership' and appear first, but this
            prevents the past Media Ethics Interns section from showing #}
         {% if vertical == False and 'Director' not in mate.getDesignation %}
-            {# this only fetches the first vertical value of the first element in the mates #}
+            {# this only fetches the first vertical value of the first non-PI element in the mates #}
             {% set vertical = mate.getVertical %}
         {% endif %}
         {% set semester_value = (mate.getTermSemester)[0] %}

--- a/wp-content/themes/engage/templates/partial/teammates.twig
+++ b/wp-content/themes/engage/templates/partial/teammates.twig
@@ -1,7 +1,9 @@
 {% set vertical = False %}
 <section class="mates grid grid--col-12 grid--gap-20">
     {% for mate in mates %}
-        {% if vertical == False %}
+        {# PIs have their first vertical value as 'Center Leadership' and appear first, but this
+           prevents the past Media Ethics Interns section from showing #}
+        {% if vertical == False and 'Director' not in mate.getDesignation %}
             {# this only fetches the first vertical value of the first element in the mates #}
             {% set vertical = mate.getVertical %}
         {% endif %}


### PR DESCRIPTION
The following changes to the staff page have been made (note: some changes involve changes that need to happen to the WordPress admin settings after the code is pushed):

- Center Leadership page has been added to the top of the team menu
- Clicking on 'Staff' on the home page footer redirects to the Center Leadership page by default
- The Center Leadership page has a custom-defined order
- Journalism, Media Ethics, Propaganda & Science Communication now have PIs (Directors & Assistant directors) appear at the top in hierarchy, followed by everyone else in alphabetical order
- For Media Ethics, some additional logic was added to make sure the new hierarchical/alphabetical sort worked for that particular page. More specifically, 1) some members not having ranks was messing up the sorting so we assigned a default rank of the highest rank possible if the person didn't have a rank (highest meaning furthest from PI) and 2) The past intern's section for Media Ethics shows if the first designation of the first person is media ethics, but the first designation of the first person was Center Leadership (followed by Media Ethics), so we got the first designation of the first non-PI person to resolve this issue
- The Staff page was renamed to Administrative & Technology
- The technology page was merged with Administrative & Technology, then deleted
- The Administrative & Technology page has no hierarchy and is only alphabetical sort
- The visiting scholars page was renamed Collaborators
- Clicking on a person in the Collaborators page now redirects to an external link that can specified for each particular person in the WordPress Admin settings
- The highlight colors for all menu options on the staff page were changed to teal