### PR TITLE
Replaced boxed header in tools page with regular header

### DIFF
--- a/wp-content/themes/engage/templates/page-tools.twig
+++ b/wp-content/themes/engage/templates/page-tools.twig
@@ -5,8 +5,8 @@
     <div class="article__wrapper container container--lg">
 		
 	<article class="article container container--lg post-type--{{post.post_type}}" id="post--{{post.ID}}">
-		<header class="article__header tile tile--vertical--journalism tile--intro">
-			<h1 class="tile__title tile__title--intro">{{post.title}}</h1>
+		<header class="article__header">
+			<h1 class="article__title">{{post.title}}</h1>
 		</header>
             
     <aside class="newsletter-about widget">


### PR DESCRIPTION
The images show what the page title looks like before and after the change
![Screen Shot 2021-03-22 at 11 54 53 AM](https://user-images.githubusercontent.com/31896484/112028046-c6b85a80-8b05-11eb-8296-cb94fb176b24.png)
![Screen Shot 2021-03-22 at 11 55 18 AM](https://user-images.githubusercontent.com/31896484/112028057-c91ab480-8b05-11eb-9b31-16029f7e447f.png)
