### PR TITLE
Fixed menu alignment in verticals

### DIFF
--- a/wp-content/themes/engage/assets/scss/components/_filter.scss
+++ b/wp-content/themes/engage/assets/scss/components/_filter.scss
@@ -61,13 +61,24 @@
 
 .filter__item--current-parent {
   padding-left: 10px;
-  margin-left: -10px;
+  margin-left: 0px;
   border-left: 3px solid $teal;
 
   .filter__link {
     &:hover {
       transform: none;
       border: none;
+    }
+  }
+}
+
+.filter__item--top-item {
+  margin-left: -10px;
+
+  .filter__link {
+    &:hover {
+      transform: none;
+      padding-left: 10px;
     }
   }
 }


### PR DESCRIPTION
The first image shows what the menu alignment on the verticals previously looked like. The next image shows what we changed the menu alignment to.

![image](https://user-images.githubusercontent.com/31896484/112520054-00d56680-8d69-11eb-99e3-72768b344bec.png)
<img width="626" alt="Screen Shot 2021-03-25 at 12 53 13 PM" src="https://user-images.githubusercontent.com/31896484/112520104-1185dc80-8d69-11eb-8374-3afc4a95eca1.png">
