### PR TITLE
Fixed redirect issue to external page for collaborators

### DIFF
--- a/wp-content/themes/engage/templates/partial/teammate.twig
+++ b/wp-content/themes/engage/templates/partial/teammate.twig
@@ -7,7 +7,7 @@
     <div class="mate__content">
       <h3 class="mate__name mate__name--{{ format }}">
           {% if (format == "preview" or "full") %}
-            {% if 'Visiting Scholar' in mate.getDesignation %}
+            {% if mate.getExternalLink != "" %}
                 {# Clicking on a Visiting Scholar redirects to an external page instead of
                 an internal bio page #}
                 <a class="mate__name" href="{{ mate.getExternalLink }}">{{ mate.name }}</a>


### PR DESCRIPTION
This code now ensures that if a collaborator has an external link specified, the page will redirect to that link instead of an internal bio page when that person is clicked