### PR TITLE
Feature/press-manual-order

### DIFF
--- a/wp-content/themes/engage-2-x/acf-json/group_5c01a01b76d95.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5c01a01b76d95.json
@@ -52,5 +52,7 @@
     "description": "",
     "show_in_rest": 0,
     "display_title": "",
-    "modified": 1770299242
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cbdeb0149fad.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cbdeb0149fad.json
@@ -240,5 +240,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1750877899
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cbdeb01642bb.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cbdeb01642bb.json
@@ -71,5 +71,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a757a9.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a757a9.json
@@ -43,5 +43,7 @@
     "description": "",
     "show_in_rest": 0,
     "display_title": "",
-    "modified": 1770299262
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a88dc2.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a88dc2.json
@@ -49,5 +49,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a904b0.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a904b0.json
@@ -458,5 +458,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0aa2089.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0aa2089.json
@@ -51,5 +51,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0acaf49.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0acaf49.json
@@ -154,5 +154,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5d5acd9802937.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5d5acd9802937.json
@@ -57,5 +57,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5d6401e29a7ff.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5d6401e29a7ff.json
@@ -46,5 +46,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5deaafc0e31e5.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5deaafc0e31e5.json
@@ -56,5 +56,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5e6aa9089d12e.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5e6aa9089d12e.json
@@ -145,5 +145,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5f0cdf67af48a.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5f0cdf67af48a.json
@@ -47,5 +47,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746613443
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_603956ed8407f.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_603956ed8407f.json
@@ -232,5 +232,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_605b23c87b698.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_605b23c87b698.json
@@ -352,5 +352,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_60d0dd33191d4.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_60d0dd33191d4.json
@@ -212,7 +212,8 @@
                     "display_format": "F j, Y",
                     "return_format": "F j, Y",
                     "first_day": 1,
-                    "parent_repeater": "field_6216b2efd1aa3"
+                    "parent_repeater": "field_6216b2efd1aa3",
+                    "default_to_current_date": 0
                 },
                 {
                     "key": "field_6216b363d1aa7",
@@ -524,5 +525,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746745751
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_60f0bc80db8ed.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_60f0bc80db8ed.json
@@ -72,5 +72,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_611c0e3ce7a94.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_611c0e3ce7a94.json
@@ -363,5 +363,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_61929af381ac0.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_61929af381ac0.json
@@ -155,7 +155,8 @@
                             "display_format": "F j, Y",
                             "return_format": "F j, Y",
                             "first_day": 1,
-                            "allow_in_bindings": 0
+                            "allow_in_bindings": 0,
+                            "default_to_current_date": 0
                         },
                         {
                             "key": "field_67eee5c875cad",
@@ -270,5 +271,8 @@
     "active": true,
     "description": "(template: page-solidarity-journalism.twig)",
     "show_in_rest": 1,
-    "modified": 1746743220
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_61ae9acd259f8.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_61ae9acd259f8.json
@@ -5570,5 +5570,7 @@
     "description": "",
     "show_in_rest": 0,
     "display_title": "",
-    "modified": 1765988021
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206900
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_61e8733652c90.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_61e8733652c90.json
@@ -112,5 +112,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_62a231d591df6.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_62a231d591df6.json
@@ -105,7 +105,10 @@
             "default_value": "#f8f8f8",
             "enable_opacity": 0,
             "return_format": "string",
-            "allow_in_bindings": 0
+            "allow_in_bindings": 0,
+            "custom_palette_source": "",
+            "palette_colors": "",
+            "show_color_wheel": true
         },
         {
             "key": "field_6791253894d14",
@@ -124,7 +127,10 @@
             "default_value": "#005f86",
             "enable_opacity": 0,
             "return_format": "string",
-            "allow_in_bindings": 0
+            "allow_in_bindings": 0,
+            "custom_palette_source": "",
+            "palette_colors": "",
+            "show_color_wheel": true
         },
         {
             "key": "field_6791581812a27",
@@ -143,7 +149,10 @@
             "default_value": "#ffffff",
             "enable_opacity": 0,
             "return_format": "string",
-            "allow_in_bindings": 0
+            "allow_in_bindings": 0,
+            "custom_palette_source": "",
+            "palette_colors": "",
+            "show_color_wheel": true
         },
         {
             "key": "field_62a237d2c293a",
@@ -345,5 +354,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_62b1f06e678ba.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_62b1f06e678ba.json
@@ -41,5 +41,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_63780934baee6.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_63780934baee6.json
@@ -84,5 +84,8 @@
     "active": true,
     "description": "(show\/hide header or newsletter module)",
     "show_in_rest": 1,
-    "modified": 1760011408
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_6643e259b0df7.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_6643e259b0df7.json
@@ -29,6 +29,198 @@
             "bidirectional_target": []
         },
         {
+            "key": "field_6a0c8b0f8713f",
+            "label": "Solidarity Journalism Videos",
+            "name": "solidarity_journalism_videos",
+            "aria-label": "",
+            "type": "relationship",
+            "instructions": "Drag to set order. All videos in this category appear automatically; new ones are added at the top until you reorder.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "press"
+            ],
+            "post_status": "",
+            "taxonomy": [
+                "press-categories:solidarity-journalism-video"
+            ],
+            "filters": [
+                "search"
+            ],
+            "return_format": "object",
+            "min": "",
+            "max": "",
+            "allow_in_bindings": 0,
+            "elements": "",
+            "bidirectional": 0,
+            "bidirectional_target": []
+        },
+        {
+            "key": "field_6a0c9779b6160",
+            "label": "Solidarity Journalism Additional Resources",
+            "name": "solidarity_journalism_additional_resources",
+            "aria-label": "",
+            "type": "relationship",
+            "instructions": "Drag to set order. All videos in this category appear automatically; new ones are added at the top until you reorder.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "press"
+            ],
+            "post_status": "",
+            "taxonomy": [
+                "press-categories:additional-resources"
+            ],
+            "filters": [
+                "search"
+            ],
+            "return_format": "object",
+            "min": "",
+            "max": "",
+            "allow_in_bindings": 0,
+            "elements": "",
+            "bidirectional": 0,
+            "bidirectional_target": []
+        },
+        {
+            "key": "field_6a0c99071464f",
+            "label": "Examples of Solidarity Reporting",
+            "name": "examples_of_solidarity_reporting",
+            "aria-label": "",
+            "type": "relationship",
+            "instructions": "Drag to set order. All videos in this category appear automatically; new ones are added at the top until you reorder.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "press"
+            ],
+            "post_status": "",
+            "taxonomy": [
+                "press-categories:solidarity-reporting"
+            ],
+            "filters": [
+                "search"
+            ],
+            "return_format": "object",
+            "min": "",
+            "max": "",
+            "allow_in_bindings": 0,
+            "elements": "",
+            "bidirectional": 0,
+            "bidirectional_target": []
+        },
+        {
+            "key": "field_6a0c9c53a1315",
+            "label": "Climate Change Articles",
+            "name": "climate_change_articles",
+            "aria-label": "",
+            "type": "relationship",
+            "instructions": "Drag to set order. All videos in this category appear automatically; new ones are added at the top until you reorder.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "press"
+            ],
+            "post_status": "",
+            "taxonomy": [
+                "press-categories:climate-change"
+            ],
+            "filters": [
+                "search"
+            ],
+            "return_format": "object",
+            "min": "",
+            "max": "",
+            "allow_in_bindings": 0,
+            "elements": "",
+            "bidirectional": 0,
+            "bidirectional_target": []
+        },
+        {
+            "key": "field_6a0c9e0787f40",
+            "label": "Dangerous Solidarity Additional Resources",
+            "name": "dangerous_solidarity_additional_resources",
+            "aria-label": "",
+            "type": "relationship",
+            "instructions": "Drag to set order. All videos in this category appear automatically; new ones are added at the top until you reorder.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "press"
+            ],
+            "post_status": "",
+            "taxonomy": [
+                "press-categories:dangerous-solidarity-additional-resources"
+            ],
+            "filters": [
+                "search"
+            ],
+            "return_format": "object",
+            "min": "",
+            "max": "",
+            "allow_in_bindings": 0,
+            "elements": "",
+            "bidirectional": 0,
+            "bidirectional_target": []
+        },
+        {
+            "key": "field_6a0c9f34f7f1b",
+            "label": "Stronger Together: Safety in Networks",
+            "name": "stronger_together_safety_in_networks",
+            "aria-label": "",
+            "type": "relationship",
+            "instructions": "Drag to set order. All videos in this category appear automatically; new ones are added at the top until you reorder.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "press"
+            ],
+            "post_status": "",
+            "taxonomy": [
+                "press-categories:stronger-together"
+            ],
+            "filters": [
+                "search"
+            ],
+            "return_format": "object",
+            "min": "",
+            "max": "",
+            "allow_in_bindings": 0,
+            "elements": "",
+            "bidirectional": 0,
+            "bidirectional_target": []
+        },
+        {
             "key": "field_6643e259a1c5a",
             "label": "Above",
             "name": "above",
@@ -87,5 +279,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746218630
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779212454
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_6793ea6c0f0a5.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_6793ea6c0f0a5.json
@@ -63,5 +63,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746216570
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_67994fb691c82.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_67994fb691c82.json
@@ -1013,5 +1013,7 @@
     "description": "",
     "show_in_rest": 0,
     "display_title": "",
-    "modified": 1762900265
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_press_article.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_press_article.json
@@ -48,7 +48,8 @@
             "display_format": "F j, Y",
             "return_format": "Ymd",
             "first_day": 1,
-            "allow_in_bindings": 1
+            "allow_in_bindings": 1,
+            "default_to_current_date": 0
         },
         {
             "key": "field_67e2c13f8e229",
@@ -137,5 +138,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746603709
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_publications.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_publications.json
@@ -40,7 +40,8 @@
             "display_format": "F j, Y",
             "return_format": "Ymd",
             "first_day": 1,
-            "allow_in_bindings": 1
+            "allow_in_bindings": 1,
+            "default_to_current_date": 0
         },
         {
             "key": "field_67dc3106fd931",
@@ -119,5 +120,8 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1746610352
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1779206899
 }

--- a/wp-content/themes/engage-2-x/includes/hooks/acf.php
+++ b/wp-content/themes/engage-2-x/includes/hooks/acf.php
@@ -94,4 +94,123 @@ if (is_plugin_active('advanced-custom-fields-pro/acf.php')) {
         }
         return $show_admin;
     });
+
+    /**
+     * Formats the press article publication date meta (Ymd) for display.
+     *
+     * @param int $post_id Press post ID.
+     */
+    function engage_press_format_publication_date_meta(int $post_id): string
+    {
+        $raw_date = get_field('press_article_publication_date', $post_id);
+        if (!is_string($raw_date) || strlen($raw_date) < 8) {
+            return '';
+        }
+
+        $timestamp = strtotime(
+            substr($raw_date, 0, 4) . '-' .
+            substr($raw_date, 4, 2) . '-' .
+            substr($raw_date, 6, 2) . ' 12:00:00'
+        );
+
+        return $timestamp ? wp_date('F j, Y', $timestamp) : '';
+    }
+
+    /**
+     * Returns the date label shown next to each press title in the relationship picker.
+     *
+     * Uses "other" text when set; otherwise the publication date field; otherwise the
+     * WordPress publish date so editors still see a date when other text is blank.
+     *
+     * @param int $post_id Press post ID.
+     * @return string Display label, or empty string when none is set.
+     */
+    function engage_press_relationship_result_label(int $post_id): string
+    {
+        if (get_field('press_article_publication_date_other', $post_id)) {
+            $other = get_field('press_article_publication_date_other_txt', $post_id);
+            if (is_string($other) && $other !== '') {
+                return $other;
+            }
+        }
+
+        $publication_date = engage_press_format_publication_date_meta($post_id);
+        if ($publication_date !== '') {
+            return $publication_date;
+        }
+
+        $post = get_post($post_id);
+        if ($post instanceof \WP_Post && $post->post_date) {
+            $timestamp = strtotime($post->post_date);
+            if ($timestamp) {
+                return wp_date('F j, Y', $timestamp);
+            }
+        }
+
+        return '';
+    }
+
+    // Each Press page gets its own order field; hide the others (shared field group).
+    // Hook by field key — acf/prepare_field runs after $field['name'] is set to the key.
+    foreach (\Engage\Models\PressPage::getManualOrderFieldKeyMap() as $field_key => $field_name) {
+        add_filter("acf/prepare_field/key={$field_key}", function ($field) use ($field_name) {
+            if (!is_array($field)) {
+                return $field;
+            }
+
+            $page_id = \Engage\Models\PressPage::getEditorPageId();
+            if ($page_id === 0 || get_post_type($page_id) !== 'page') {
+                return false;
+            }
+
+            if (!\Engage\Models\PressPage::shouldShowManualOrderField($field_name, $page_id)) {
+                return false;
+            }
+
+            $field['wrapper']['class'] = trim(($field['wrapper']['class'] ?? '') . ' acf-press-manual-order');
+
+            return $field;
+        });
+    }
+
+    // Date / "other" label beside titles in all manual-order relationship pickers.
+    add_filter('acf/fields/relationship/result', function ($title, $post, $field, $post_id) {
+        $field_name = is_array($field)
+            ? \Engage\Models\PressPage::resolveManualOrderFieldName($field)
+            : null;
+
+        if ($field_name === null) {
+            return $title;
+        }
+
+        if (!($post instanceof \WP_Post) || $post->post_type !== 'press') {
+            return $title;
+        }
+
+        $label = engage_press_relationship_result_label((int) $post->ID);
+        if ($label === '') {
+            return $title;
+        }
+
+        return $title . '<span class="acf-relationship-press-meta"> — ' . esc_html($label) . '</span>';
+    }, 10, 4);
+
+    // Press manual-order relationship fields: date suffix + taller pick lists.
+    add_action('acf/input/admin_enqueue_scripts', function () {
+        if (!function_exists('get_current_screen')) {
+            return;
+        }
+
+        $screen = get_current_screen();
+        if (!$screen || $screen->base !== 'post' || $screen->post_type !== 'page') {
+            return;
+        }
+
+        wp_add_inline_style(
+            'acf-input',
+            '.acf-relationship .acf-relationship-press-meta{color:#646970;font-weight:400;}'
+            // ACF sets .acf-relationship .list { height: 160px } — override the scrollable lists.
+            . '.acf-press-manual-order .acf-relationship .list{height:20rem!important;}'
+        );
+    });
 } 

--- a/wp-content/themes/engage-2-x/page-press.php
+++ b/wp-content/themes/engage-2-x/page-press.php
@@ -2,52 +2,28 @@
 /**
  * Template Name: Press
  * Description: A Page Template for Press
+ *
+ * Lists press posts by categories selected in ACF. Some Press pages also support
+ * manual drag order via a page-specific relationship field (see PressPage).
  */
 
+use Engage\Models\PressPage;
 use Timber\Timber;
 
 $context = Timber::context();
 $post    = $context['post'];
 
-// Get the term objects from ACF field
-$terms = get_field('posts'); // This will return term objects since that's selected in ACF
+$terms = get_field('posts');
 
-// Get posts from those terms if terms exist
 if ($terms && !empty($terms)) {
-    // Extract term IDs from term objects
-    $term_ids = array_map(function($term) {
+    $term_ids = array_map(static function ($term) {
         return $term->term_id;
     }, $terms);
 
-    $press_posts = get_posts([
-        'post_type' => 'press',
-        'numberposts' => -1,
-        'meta_query' => [
-            'relation' => 'OR',
-            [
-                'key' => 'press_article_publication_date',
-                'compare' => 'EXISTS',
-                'type' => 'DATE'
-            ],
-            [
-                'key' => 'press_article_publication_date',
-                'compare' => 'NOT EXISTS'
-            ]
-        ],
-        'orderby' => [
-            'press_article_publication_date' => 'DESC',
-            'press_article_publisher' => 'ASC'
-        ],
-        'tax_query' => [
-            [
-                'taxonomy' => 'press-categories',
-                'field'    => 'term_id',
-                'terms'    => $term_ids
-            ]
-        ]
-    ]);
+    $press_posts = PressPage::getPostsByTermIds($term_ids);
 
-    // Convert to Timber posts
+    $press_posts = PressPage::orderPressPosts($press_posts, PressPage::getManualOrder($post->ID));
+
     $context['press_posts'] = Timber::get_posts($press_posts);
 } else {
     $context['press_posts'] = [];

--- a/wp-content/themes/engage-2-x/src/Models/PressPage.php
+++ b/wp-content/themes/engage-2-x/src/Models/PressPage.php
@@ -1,44 +1,292 @@
 <?php
 /**
- * Class Press
+ * Helpers for pages that use the Press page template.
+ *
+ * Most Press pages list items by category and sort by publication date. Some
+ * pages also have a per-page ACF relationship field for drag-to-reorder; see
+ * MANUAL_ORDER_PAGES, getManualOrderFieldName(), and orderPressPosts().
  */
 namespace Engage\Models;
 
 use Timber\Post;
+use WP_Post;
 
 class PressPage extends Post
 {
+    /**
+     * Press pages with manual order.
+     *
+     * Add a row when you create a new relationship field: page slug, ACF field
+     * name, and field key (from acf-json). Slugs are used instead of post IDs.
+     */
+    private const MANUAL_ORDER_PAGES = [
+        'solidarity-journalism-videos' => [
+            'field' => 'solidarity_journalism_videos',
+            'key' => 'field_6a0c8b0f8713f',
+        ],
+        'solidarity-reporting-additional-resources' => [
+            'field' => 'solidarity_journalism_additional_resources',
+            'key' => 'field_6a0c9779b6160',
+        ],
+        'examples-of-solidarity-reporting' => [
+            'field' => 'examples_of_solidarity_reporting',
+            'key' => 'field_6a0c99071464f',
+        ],
+        'climate-change-articles' => [
+            'field' => 'climate_change_articles',
+            'key' => 'field_6a0c9c53a1315',
+        ],
+        'dangerous-solidarity-additional-resources' => [
+            'field' => 'dangerous_solidarity_additional_resources',
+            'key' => 'field_6a0c9e0787f40',
+        ],
+        'stronger-together-safety-in-networks' => [
+            'field' => 'stronger_together_safety_in_networks',
+            'key' => 'field_6a0c9f34f7f1b',
+        ],
+    ];
+
     public $columns;
     public $rows;
     public $html_string;
+
     /**
-     * Estimates time required to read a post.
+     * ACF relationship field names used for manual press ordering on Press pages.
      *
-     * The words per minute are based on the English language, which e.g. is much
-     * faster than German or French.
-     *
-     * @link https://www.irisreading.com/average-reading-speed-in-various-languages/
-     *
-     * @return string
+     * @return string[]
      */
+    public static function getManualOrderFieldNames(): array
+    {
+        return array_column(self::MANUAL_ORDER_PAGES, 'field');
+    }
+
+    /**
+     * ACF field keys for manual-order relationship fields (for prepare_field/key hooks).
+     *
+     * @return array<string, string> field_key => field_name
+     */
+    public static function getManualOrderFieldKeyMap(): array
+    {
+        $map = [];
+        foreach (self::MANUAL_ORDER_PAGES as $config) {
+            $map[$config['key']] = $config['field'];
+        }
+
+        return $map;
+    }
+
+    /**
+     * Whether an ACF field is a registered manual-order relationship field.
+     */
+    public static function isManualOrderField(string $field_name): bool
+    {
+        return in_array($field_name, self::getManualOrderFieldNames(), true);
+    }
+
+    /**
+     * Resolves the manual-order field name from an ACF field array.
+     *
+     * Prefer field key (reliable in acf/prepare_field); fall back to _name / name.
+     *
+     * @param array<string, mixed> $field ACF field array.
+     */
+    public static function resolveManualOrderFieldName(array $field): ?string
+    {
+        $key = (string) ($field['key'] ?? '');
+        $key_map = self::getManualOrderFieldKeyMap();
+        if ($key !== '' && isset($key_map[$key])) {
+            return $key_map[$key];
+        }
+
+        $name = (string) ($field['_name'] ?? $field['name'] ?? '');
+        if ($name !== '' && self::isManualOrderField($name)) {
+            return $name;
+        }
+
+        return null;
+    }
+
+    /**
+     * Page ID for the post currently being edited in wp-admin (ACF screen).
+     */
+    public static function getEditorPageId(): int
+    {
+        if (function_exists('acf_get_form_data')) {
+            $post_id = acf_get_form_data('post_id');
+            if (is_numeric($post_id) && (int) $post_id > 0) {
+                return (int) $post_id;
+            }
+        }
+
+        if (isset($_GET['post']) && is_numeric($_GET['post'])) {
+            return (int) $_GET['post'];
+        }
+
+        global $post;
+
+        if ($post instanceof WP_Post && $post->post_type === 'page') {
+            return (int) $post->ID;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Returns the manual-order ACF field name for a Press page, if configured.
+     *
+     * @param int $page_id WordPress page ID.
+     * @return string|null ACF field name, or null when this page uses date sort only.
+     */
+    public static function getManualOrderFieldName(int $page_id): ?string
+    {
+        $slug = get_post_field('post_name', $page_id);
+
+        return self::MANUAL_ORDER_PAGES[$slug]['field'] ?? null;
+    }
+
+    /**
+     * Whether a manual-order field should show in the editor for this page.
+     */
+    public static function shouldShowManualOrderField(string $field_name, int $page_id): bool
+    {
+        return self::getManualOrderFieldName($page_id) === $field_name;
+    }
+
+    /**
+     * Loads drag-order values from the relationship field mapped to this page.
+     *
+     * @param int $page_id WordPress page ID.
+     * @return array<int, mixed>|null Relationship field value, or null if not mapped.
+     */
+    public static function getManualOrder(int $page_id): ?array
+    {
+        $field_name = self::getManualOrderFieldName($page_id);
+        if ($field_name === null) {
+            return null;
+        }
+
+        $value = get_field($field_name, $page_id);
+
+        if ($value === null || $value === false || $value === []) {
+            return null;
+        }
+
+        return is_array($value) ? $value : null;
+    }
+
+    /**
+     * Fetches every published press item in the categories chosen on the page.
+     *
+     * Editors pick categories in the Press ACF "Posts" field; this returns all
+     * matching press posts. Sorting is handled separately by orderPressPosts().
+     *
+     * @param int[] $term_ids Press category term IDs from the page ACF field.
+     * @return WP_Post[]
+     */
+    public static function getPostsByTermIds(array $term_ids): array
+    {
+        if ($term_ids === []) {
+            return [];
+        }
+
+        return get_posts([
+            'post_type' => 'press',
+            'numberposts' => -1,
+            'post_status' => 'publish',
+            'tax_query' => [
+                [
+                    'taxonomy' => 'press-categories',
+                    'field' => 'term_id',
+                    'terms' => $term_ids,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Builds the final list order for a Press page.
+     *
+     * Category membership decides which posts appear. When editors have set a
+     * manual order, those posts follow drag order. Any other posts in the category
+     * are placed first, newest publication date first, so new items show up
+     * without editing the page.
+     *
+     * @param WP_Post[] $posts All posts from the selected categories.
+     * @param WP_Post[]|array<int>|null|false $manual_order Posts from the ACF
+     *   relationship field (drag order), or null/false to sort by date only.
+     * @return WP_Post[]
+     */
+    public static function orderPressPosts(array $posts, $manual_order): array
+    {
+        if ($manual_order === null || $manual_order === [] || $manual_order === false) {
+            return self::sortByPublicationDate($posts);
+        }
+
+        $posts_by_id = [];
+        foreach ($posts as $post) {
+            $posts_by_id[$post->ID] = $post;
+        }
+
+        $ordered = [];
+        foreach ($manual_order as $manual_post) {
+            $id = is_object($manual_post) ? $manual_post->ID : (int) $manual_post;
+            if (isset($posts_by_id[$id])) {
+                $ordered[] = $posts_by_id[$id];
+                unset($posts_by_id[$id]);
+            }
+        }
+
+        $remaining = self::sortByPublicationDate(array_values($posts_by_id));
+
+        return array_merge($remaining, $ordered);
+    }
+
+    /**
+     * Sorts press posts by publication date, newest first.
+     *
+     * Used as the default on generic Press pages and for posts that are not yet
+     * in the manual order list. Falls back to WordPress post date, then title.
+     *
+     * @param WP_Post[] $posts
+     * @return WP_Post[]
+     */
+    public static function sortByPublicationDate(array $posts): array
+    {
+        usort($posts, static function (WP_Post $a, WP_Post $b): int {
+            $date_a = (string) get_post_meta($a->ID, 'press_article_publication_date', true);
+            $date_b = (string) get_post_meta($b->ID, 'press_article_publication_date', true);
+
+            if ($date_a !== $date_b) {
+                return strcmp($date_b, $date_a);
+            }
+
+            $post_date_cmp = strcmp($b->post_date, $a->post_date);
+            if ($post_date_cmp !== 0) {
+                return $post_date_cmp;
+            }
+
+            return strcasecmp($a->post_title, $b->post_title);
+        });
+
+        return $posts;
+    }
 
     public function generate_table()
     {
         $this->generateTableStructure($this->content);
     }
-    
+
     public function generateTableStructure($html_input)
     {
-        $removed_tags = explode('</p>', implode("", explode('<p>', $html_input)));
-        # column headers will be the first row
+        $removed_tags = explode('</p>', implode('', explode('<p>', $html_input)));
         $rows = [];
         foreach ($removed_tags as $comma_row) {
             $row_seperated = explode('|', trim($comma_row));
-            if(count($row_seperated) > 0 && strlen($row_seperated[0]) > 0){
-                array_push($rows, $row_seperated); 
+            if (count($row_seperated) > 0 && strlen($row_seperated[0]) > 0) {
+                array_push($rows, $row_seperated);
             }
         }
-        $this->columns = array_shift($rows  );
+        $this->columns = array_shift($rows);
         $this->rows = $rows;
     }
 }


### PR DESCRIPTION
- Introduced constants for manual order pages and added methods to retrieve ACF field names and keys.
- Implemented functionality to resolve manual order field names and check if a field is a manual order field.
- Added methods to fetch and manage posts by term IDs, including sorting by publication date and handling manual order relationships.

These updates improve the flexibility and usability of the Press page template in managing press articles.