### PR TITLE
Feature/wysiwyg-custom-posts

### DIFF
--- a/wp-content/themes/engage-2-x/acf-json/group_5c01a01b76d95.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5c01a01b76d95.json
@@ -54,5 +54,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cbdeb0149fad.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cbdeb0149fad.json
@@ -243,5 +243,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cbdeb01642bb.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cbdeb01642bb.json
@@ -74,5 +74,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a757a9.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a757a9.json
@@ -45,5 +45,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a88dc2.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a88dc2.json
@@ -52,5 +52,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a904b0.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0a904b0.json
@@ -461,5 +461,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0aa2089.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0aa2089.json
@@ -54,5 +54,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0acaf49.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5cdc6f0acaf49.json
@@ -157,5 +157,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5d5acd9802937.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5d5acd9802937.json
@@ -60,5 +60,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5d6401e29a7ff.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5d6401e29a7ff.json
@@ -49,5 +49,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5deaafc0e31e5.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5deaafc0e31e5.json
@@ -59,5 +59,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5e6aa9089d12e.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5e6aa9089d12e.json
@@ -148,5 +148,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_5f0cdf67af48a.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_5f0cdf67af48a.json
@@ -50,5 +50,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_603956ed8407f.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_603956ed8407f.json
@@ -235,5 +235,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_605b23c87b698.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_605b23c87b698.json
@@ -355,5 +355,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_60d0dd33191d4.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_60d0dd33191d4.json
@@ -220,8 +220,8 @@
                     "label": "Excerpt",
                     "name": "excerpt",
                     "aria-label": "",
-                    "type": "textarea",
-                    "instructions": "",
+                    "type": "wysiwyg",
+                    "instructions": "Use the toolbar to apply formatting such as italics or bold.",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -230,10 +230,11 @@
                         "id": ""
                     },
                     "default_value": "Advertiser information for cable and nightly network news broadcasts.",
-                    "placeholder": "",
-                    "maxlength": "",
-                    "rows": "",
-                    "new_lines": "",
+                    "allow_in_bindings": 0,
+                    "tabs": "visual",
+                    "toolbar": "basic",
+                    "media_upload": 0,
+                    "delay": 0,
                     "parent_repeater": "field_6216b2efd1aa3"
                 },
                 {
@@ -528,5 +529,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782763149
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_60f0bc80db8ed.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_60f0bc80db8ed.json
@@ -75,5 +75,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_611c0e3ce7a94.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_611c0e3ce7a94.json
@@ -366,5 +366,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_61929af381ac0.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_61929af381ac0.json
@@ -163,8 +163,8 @@
                             "label": "Excerpt",
                             "name": "excerpt",
                             "aria-label": "",
-                            "type": "textarea",
-                            "instructions": "",
+                            "type": "wysiwyg",
+                            "instructions": "Use the toolbar to apply formatting such as italics or bold.",
                             "required": 0,
                             "conditional_logic": 0,
                             "wrapper": {
@@ -173,11 +173,11 @@
                                 "id": ""
                             },
                             "default_value": "",
-                            "maxlength": "",
                             "allow_in_bindings": 0,
-                            "rows": "",
-                            "placeholder": "",
-                            "new_lines": ""
+                            "tabs": "visual",
+                            "toolbar": "basic",
+                            "media_upload": 0,
+                            "delay": 0
                         },
                         {
                             "key": "field_67eee5e775cae",
@@ -274,5 +274,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782763080
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_61ae9acd259f8.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_61ae9acd259f8.json
@@ -5572,5 +5572,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206900
+    "modified": 1782761294
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_61e8733652c90.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_61e8733652c90.json
@@ -115,5 +115,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_62a231d591df6.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_62a231d591df6.json
@@ -357,5 +357,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_62b1f06e678ba.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_62b1f06e678ba.json
@@ -44,5 +44,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_63780934baee6.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_63780934baee6.json
@@ -87,5 +87,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_6643e259b0df7.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_6643e259b0df7.json
@@ -282,5 +282,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779212454
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_6793ea6c0f0a5.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_6793ea6c0f0a5.json
@@ -66,5 +66,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_67994fb691c82.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_67994fb691c82.json
@@ -1015,5 +1015,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761293
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_press_article.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_press_article.json
@@ -141,5 +141,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/acf-json/group_publications.json
+++ b/wp-content/themes/engage-2-x/acf-json/group_publications.json
@@ -123,5 +123,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779206899
+    "modified": 1782761292
 }

--- a/wp-content/themes/engage-2-x/templates/page-connective-democracy.twig
+++ b/wp-content/themes/engage-2-x/templates/page-connective-democracy.twig
@@ -67,7 +67,7 @@
 									</div>
 									<h2 class="tile__title h3">{{ item.title }}</h2>
 									<p class="tile__date">{{ item.date }}</p>
-									<div class="tile__excerpt">{{ item.excerpt }}</div>
+									<div class="tile__excerpt">{{ item.excerpt|wp_kses_post }}</div>
 								</div>
 								<a class="tile__link" href="{{ item.link }}" {% if item.link_in_blank %}target="_blank"{% endif %}>
 									<span class="sr-text">{{ item.link_title }}</span>

--- a/wp-content/themes/engage-2-x/templates/partial/tile.twig
+++ b/wp-content/themes/engage-2-x/templates/partial/tile.twig
@@ -14,21 +14,21 @@ Other tiles have a link to the post URL
 {% if post_type == 'press' %}
 	{% set tile_link = tile.meta('press_article_url') %}
 	{# 
-				for press tiles in the solidarity-journalism-video	category, 
-				`press_article_publication_date_other` will be true, so
-				we need to get the `press_article_publication_date_other_txt` field in place of the date
-			#}
+		for press tiles in the solidarity-journalism-video	category, 
+		`press_article_publication_date_other` will be true, so
+		we need to get the `press_article_publication_date_other_txt` field in place of the date
+	#}
 	{% if tile.meta('press_article_publication_date_other') %}
 		{% set tile_date = tile.meta('press_article_publication_date_other_txt') %}
 	{% else %}
 		{% set raw_date = tile.meta('press_article_publication_date') %}
 		{% if raw_date %}
 			{# 
-										Append ' 12:00:00' to ensure the date is always interpreted as midday UTC.
-										This prevents timezone conversion from rolling the date back a day
-										when displaying in US timezones (e.g., Chicago, Los Angeles).
-										The database stores only the date (YYYYMMDD), so we add a time for safe display.
-									#}
+				Append ' 12:00:00' to ensure the date is always interpreted as midday UTC.
+				This prevents timezone conversion from rolling the date back a day
+				when displaying in US timezones (e.g., Chicago, Los Angeles).
+				The database stores only the date (YYYYMMDD), so we add a time for safe display.
+			#}
 			{% set formatted_date = raw_date|slice(0,4) ~ '-' ~ raw_date|slice(4,2) ~ '-' ~ raw_date|slice(6,2) ~ ' 12:00:00' %}
 			{% set tile_date = formatted_date|date('F j, Y', wp_timezone) %}
 		{% else %}
@@ -140,7 +140,7 @@ Other tiles have a link to the post URL
 		{% if post_type != 'press' and post_type != 'publication' %}
 			{% if tile.excerpt %}
 				<div class="tile__excerpt">
-					{{ tile.excerpt }}
+					{{ tile.excerpt|wp_kses_post }}
 				</div>
 			{% endif %}
 		{% endif %}


### PR DESCRIPTION
Custom tile excerpts were plain text only, so editors couldn't italicize book titles or other inline formatting. This branch switches those excerpt fields to a basic WYSIWYG editor and sanitizes the HTML on output.

## Changes
- **Solidarity Journalism** — Custom tile Excerpt field changed from Text Area to WYSIWYG (Basic toolbar: italic, bold, link)
- **Connective Democracy** — Custom post Excerpt field updated the same way
- **`tile.twig`** — Tile excerpts output through `wp_kses_post` so allowed formatting renders safely
- **`page-connective-democracy.twig`** — Same sanitization for custom post excerpts
- **ACF JSON sync** — Updated `modified` timestamps across field group JSON files after local ACF sync

## Test plan
- [ ] Sync ACF field groups in WP admin if prompted (Solidarity Journalism + Connective Democracy)
- [ ] **Solidarity Journalism** — Edit a custom tile excerpt, italicize text (e.g. book title), save, and confirm formatting on the front end
- [ ] **Connective Democracy** — Same test on a custom post excerpt
- [ ] Confirm existing plain-text excerpts still display correctly (no broken markup)
- [ ] Spot-check a regular tile excerpt (non-custom post) still renders as expected
- [ ] Verify press/publication tiles are unchanged (excerpt block is skipped for those post types)